### PR TITLE
Automatically `init`

### DIFF
--- a/boilr.go
+++ b/boilr.go
@@ -1,7 +1,22 @@
 package main
 
-import "github.com/tmrts/boilr/pkg/cmd"
+import (
+  "fmt"
+  "github.com/tmrts/boilr/pkg/boilr"
+  "github.com/tmrts/boilr/pkg/cmd"
+  "github.com/tmrts/boilr/pkg/util/exit"
+  "github.com/tmrts/boilr/pkg/util/osutil"
+)
 
 func main() {
-	cmd.Run()
+  if exists, err := osutil.DirExists(boilr.Configuration.TemplateDirPath); ! exists {
+    if err := osutil.CreateDirs(boilr.Configuration.TemplateDirPath); err != nil {
+      exit.Error(fmt.Errorf("Tried to initialise your template directory, but it has failed: %s", err))
+    }
+  } else if err != nil {
+    exit.Error(fmt.Errorf("Failed to init: %s", err))
+  }
+
+  cmd.Run()
 }
+


### PR DESCRIPTION
Boilr should ensure the configuration directory exists, rather than relying on installation script or a user running 'init'

I'm not sure if this is something you'll want to merge, but I think the user-experience is nicer.

Should you wish to adopt this, I'm happy to update this PR and remove `init` command completely, if wanted.