### PR TITLE
Feature: Update a Template

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -33,6 +33,8 @@ func Run() {
 	Save.PersistentFlags().BoolP("force", "f", false, "Overwrite existing template with the same name")
 	Template.AddCommand(Save)
 
+	Template.AddCommand(Update)
+
 	Use.PersistentFlags().BoolP("use-defaults", "f", false, "Uses default values in project.json instead of prompting the user")
 	Use.PersistentFlags().StringP("log-level", "l", "error", "log-level for output")
 	Template.AddCommand(Use)

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	cli "github.com/spf13/cobra"
+
+	"github.com/tmrts/boilr/pkg/boilr"
+	"github.com/tmrts/boilr/pkg/util/exit"
+	"github.com/tmrts/boilr/pkg/util/git"
+	"github.com/tmrts/boilr/pkg/util/osutil"
+	"github.com/tmrts/boilr/pkg/util/validate"
+	gogit "gopkg.in/src-d/go-git.v4"
+)
+
+// CLI command for updating a template
+var Update = &cli.Command{
+	Use:   "update <template-tag>",
+	Short: "Update a project template from a github repository",
+	Run: func(c *cli.Command, args []string) {
+		MustValidateArgs(args, []validate.Argument{
+			{"template-tag", validate.AlphanumericExt},
+		})
+
+		MustValidateTemplateDir()
+
+		templateName := args[0]
+
+		targetDir, err := boilr.TemplatePath(templateName)
+		if err != nil {
+			exit.Error(fmt.Errorf("download: %s", err))
+		}
+
+		switch exists, err := osutil.DirExists(targetDir); {
+		case err != nil:
+			exit.Error(fmt.Errorf("updatee: %s", err))
+		case !exists:
+      exit.OK("Couldn't find '%s' template to update. Have you downloaded it?", templateName)
+		}
+
+    repository, err := git.Open(targetDir)
+    if err != nil {
+      exit.Error(fmt.Errorf("Failed to update repository '%s': %s", targetDir, err))
+    }
+
+    if err := repository.Pull(&gogit.PullOptions{RemoteName: "origin"}); err != nil {
+      exit.Error(fmt.Errorf("Failed to update repository '%s': %s", targetDir, err))
+    }
+
+		exit.OK("Successfully updated the template %#v", templateName)
+	},
+}

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	cli "github.com/spf13/cobra"
 
@@ -37,6 +39,12 @@ var Update = &cli.Command{
 		case !exists:
       exit.OK("Couldn't find '%s' template to update. Have you downloaded it?", templateName)
 		}
+
+    // We don't mind if this fails, as if the file doesn't exist; we can update the repo.
+    // Further work to be carried out with regards to metadata
+    // See: https://github.com/tmrts/boilr/pull/43#issuecomment-289391044<Paste>
+    metadataPath := filepath.Join(targetDir, boilr.TemplateMetadataName)
+    os.Remove(metadataPath)
 
     repository, err := git.Open(targetDir)
     if err != nil {

--- a/pkg/util/git/git.go
+++ b/pkg/util/git/git.go
@@ -1,7 +1,7 @@
 // Package git is a facade for git methods used by boilr
 package git
 
-import git "srcd.works/go-git.v4"
+import git "gopkg.in/src-d/go-git.v4"
 
 // CloneOptions are used when cloning a git repository
 type CloneOptions git.CloneOptions

--- a/pkg/util/git/git.go
+++ b/pkg/util/git/git.go
@@ -3,8 +3,9 @@ package git
 
 import git "gopkg.in/src-d/go-git.v4"
 
-// CloneOptions are used when cloning a git repository
+// Options are used when cloning or pulling from a git repository
 type CloneOptions git.CloneOptions
+type PullOptions git.PullOptions
 
 // Clone clones a git repository with the given options
 func Clone(dir string, opts CloneOptions) error {
@@ -13,3 +14,8 @@ func Clone(dir string, opts CloneOptions) error {
 	_, err := git.PlainClone(dir, false, &o)
 	return err
 }
+
+func Open(path string) (*git.Repository, error) {
+  return git.PlainOpen(path)
+}
+


### PR DESCRIPTION
Hi @tmrts,

This PR **is not** ready for merge yet, as I'm sure you'll see. I got this so-far and I'm not sure how to solve the next problem.

When running the `Pull`, this does seem to work but then fails with `work tree not clean`, which is due to the `metadata.json`

Thoughts on this?

I checked `go-git`'s docs for `PullOptions`, but can't see anything to ignore this.