### PR TITLE
Extracting strings to central location

### DIFF
--- a/boilr.go
+++ b/boilr.go
@@ -19,4 +19,3 @@ func main() {
 
   cmd.Run()
 }
-

--- a/pkg/boilr/errors.go
+++ b/pkg/boilr/errors.go
@@ -1,8 +1,0 @@
-package boilr
-
-import "errors"
-
-var (
-	// ErrTemplateAlreadyExists indicates that a template is already present in the local registry.
-	ErrTemplateAlreadyExists = errors.New("boilr: project template already exists")
-)

--- a/pkg/cmd/download.go
+++ b/pkg/cmd/download.go
@@ -32,20 +32,20 @@ var Download = &cli.Command{
 
 		targetDir, err := boilr.TemplatePath(templateName)
 		if err != nil {
-      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
+			exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		}
 
 		switch exists, err := osutil.DirExists(targetDir); {
 		case err != nil:
-      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
+			exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		case exists:
 			if shouldOverwrite := GetBoolFlag(c, "force"); !shouldOverwrite {
-			  exit.Error(fmt.Errorf("%s", strings.ErrTemplateAlreadyExists(templateName)))
+				exit.Error(fmt.Errorf("%s", strings.ErrTemplateAlreadyExists(templateName)))
 			}
 
 			// TODO(tmrts): extract `template delete` helper and use that one
 			if err := os.RemoveAll(targetDir); err != nil {
-        exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
+				exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 			}
 		}
 
@@ -53,14 +53,14 @@ var Download = &cli.Command{
 		if err := git.Clone(targetDir, git.CloneOptions{
 			URL: host.URL(templateURL),
 		}); err != nil {
-      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
+			exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		}
 
 		// TODO(tmrts): use git-notes as metadata storage or boltdb
 		if err := serializeMetadata(templateName, templateURL, targetDir); err != nil {
-      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
+			exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		}
 
-    exit.OK("%s: %#v", strings.DownloadSuccessful, templateName)
+		exit.OK("%s: %#v", strings.DownloadSuccessful, templateName)
 	},
 }

--- a/pkg/cmd/download.go
+++ b/pkg/cmd/download.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tmrts/boilr/pkg/util/exit"
 	"github.com/tmrts/boilr/pkg/util/git"
 	"github.com/tmrts/boilr/pkg/util/osutil"
+	"github.com/tmrts/boilr/pkg/util/strings"
 	"github.com/tmrts/boilr/pkg/util/validate"
 )
 
@@ -31,20 +32,20 @@ var Download = &cli.Command{
 
 		targetDir, err := boilr.TemplatePath(templateName)
 		if err != nil {
-			exit.Error(fmt.Errorf("download: %s", err))
+      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		}
 
 		switch exists, err := osutil.DirExists(targetDir); {
 		case err != nil:
-			exit.Error(fmt.Errorf("download: %s", err))
+      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		case exists:
 			if shouldOverwrite := GetBoolFlag(c, "force"); !shouldOverwrite {
-				exit.OK("Template %v already exists use -f to overwrite the template", templateName)
+			  exit.Error(fmt.Errorf("%s", strings.ErrTemplateAlreadyExists(templateName)))
 			}
 
 			// TODO(tmrts): extract `template delete` helper and use that one
 			if err := os.RemoveAll(targetDir); err != nil {
-				exit.Error(fmt.Errorf("download: %s", err))
+        exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 			}
 		}
 
@@ -52,14 +53,14 @@ var Download = &cli.Command{
 		if err := git.Clone(targetDir, git.CloneOptions{
 			URL: host.URL(templateURL),
 		}); err != nil {
-			exit.Error(fmt.Errorf("download: %s", err))
+      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		}
 
 		// TODO(tmrts): use git-notes as metadata storage or boltdb
 		if err := serializeMetadata(templateName, templateURL, targetDir); err != nil {
-			exit.Error(fmt.Errorf("download: %s", err))
+      exit.Error(fmt.Errorf("%s: %s", strings.ErrDownloadFailedGeneric, err))
 		}
 
-		exit.OK("Successfully downloaded the template %#v", templateName)
+    exit.OK("%s: %#v", strings.DownloadSuccessful, templateName)
 	},
 }

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -1,0 +1,15 @@
+package strings
+
+import "fmt"
+
+var (
+  // Download Successful
+  DownloadSuccessful = "Successfully downloaded template"
+
+	// Download Errors
+	ErrDownloadFailedGeneric = "Failed to download template"
+
+  ErrTemplateAlreadyExists = func(templateName string) string {
+    return fmt.Sprintf("%s: Template (%s) already exists. Use -f to overwrite", ErrDownloadFailedGeneric, templateName)
+  }
+)

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -3,13 +3,13 @@ package strings
 import "fmt"
 
 var (
-  // Download Successful
-  DownloadSuccessful = "Successfully downloaded template"
+	// Download Successful
+	DownloadSuccessful = "Successfully downloaded template"
 
 	// Download Errors
 	ErrDownloadFailedGeneric = "Failed to download template"
 
-  ErrTemplateAlreadyExists = func(templateName string) string {
-    return fmt.Sprintf("%s: Template (%s) already exists. Use -f to overwrite", ErrDownloadFailedGeneric, templateName)
-  }
+	ErrTemplateAlreadyExists = func(templateName string) string {
+		return fmt.Sprintf("%s: Template (%s) already exists. Use -f to overwrite", ErrDownloadFailedGeneric, templateName)
+	}
 )


### PR DESCRIPTION
Submitting this early, in-case this is wasted time. My thoughts were:

1. Extract strings to `pkg/utils/strings`
2. Cleaning up / clarifying error messages as I go (See #27)
3. Implement internationalization / translations