### PR TITLE
Add trimPrefix and trimSuffix to template functions

### DIFF
--- a/pkg/template/functions.go
+++ b/pkg/template/functions.go
@@ -81,7 +81,9 @@ var (
 		"toTitle": strings.ToTitle,
 		"title":   strings.Title,
 
-		"trimSpace": strings.TrimSpace,
+		"trimSpace":  strings.TrimSpace,
+		"trimPrefix": strings.TrimPrefix,
+		"trimSuffix": strings.TrimSuffix,
 
 		"repeat": strings.Repeat,
 	}


### PR DESCRIPTION
I've found `trimPrefix` very useful. For example, when generating a Go package, finding the package path automatically:
```
{{ $pkg := (print (env "GOPATH") "/src/" | trimPrefix (env "PWD")) -}}
```
I also added `trimSuffix` for the sake of completeness.