### PR TITLE
bug fix: errors reading `project.json`

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -63,6 +63,9 @@ func Get(path string) (Interface, error) {
 
 		return metadata, nil
 	}(filepath.Join(absPath, boilr.ContextFileName))
+	if err != nil {
+		return nil, err
+	}
 
 	metadataExists, err := osutil.FileExists(filepath.Join(absPath, boilr.TemplateMetadataName))
 	if err != nil {


### PR DESCRIPTION
An error was being ignored. I suggest adding linting (gometalinter) and/or tests (godog / ginkgo / gomega) to this project 