### PR TITLE
add camel function for template

### DIFF
--- a/pkg/template/functions.go
+++ b/pkg/template/functions.go
@@ -93,7 +93,8 @@ var (
 		"trimPrefix": strings.TrimPrefix,
 		"trimSuffix": strings.TrimSuffix,
 
-		"repeat": strings.Repeat,
+		"repeat":  strings.Repeat,
+		"replace": strings.Replace,
 
 		// camel splits a string by a separator and recombines while
 		// capitalizing the first character in each part

--- a/pkg/template/functions.go
+++ b/pkg/template/functions.go
@@ -94,6 +94,16 @@ var (
 		"trimSuffix": strings.TrimSuffix,
 
 		"repeat": strings.Repeat,
+
+		// camel splits a string by a separator and recombines while
+		// capitalizing the first character in each part
+		"camel": func(value, sep string) (result string) {
+			parts := strings.Split(value, sep)
+			for _, part := range parts {
+				result += strings.Title(part)
+			}
+			return
+		},
 	}
 
 	// Options contain the default options for the template execution.

--- a/pkg/template/functions.go
+++ b/pkg/template/functions.go
@@ -99,7 +99,8 @@ var (
 		// capitalizing the first character in each part
 		"camel": func(value, sep string) (result string) {
 			parts := strings.Split(value, sep)
-			for _, part := range parts {
+			result = parts[0]
+			for _, part := range parts[1:] {
 				result += strings.Title(part)
 			}
 			return


### PR DESCRIPTION
Converts delimited strings to camel.  This is helpful for generating variable names that stem from hyphenated string values.