### PR TITLE
Add os.O_TRUNC flag to os.OpenFile to solve trailing junk issue.

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -214,7 +214,7 @@ func (t *dirTemplate) Execute(dirPrefix string) error {
 				return err
 			}
 
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY, fi.Mode())
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fi.Mode())
 			if err != nil {
 				return err
 			}

--- a/pkg/util/osutil/fs.go
+++ b/pkg/util/osutil/fs.go
@@ -97,7 +97,7 @@ func CopyRecursively(srcPath, dstPath string) error {
 			}
 			defer srcf.Close()
 
-			dstf, err := os.OpenFile(mirrorPath, os.O_CREATE|os.O_WRONLY, fi.Mode())
+			dstf, err := os.OpenFile(mirrorPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fi.Mode())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Without the O_TRUNC flag, if `boilr` is run more than once, and the resulting output is shorter than the previous run, then the resulting files have leftovers at the end from the previous file contents. 