### PR TITLE
Fixes issue with late-binding inside closure

### DIFF
--- a/pkg/cmd/use.go
+++ b/pkg/cmd/use.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/tmrts/boilr/pkg/util/tlog"
+
 	cli "github.com/spf13/cobra"
 
 	"github.com/tmrts/boilr/pkg/boilr"
@@ -67,6 +69,8 @@ var Use = &cli.Command{
 		if shouldUseDefaults := GetBoolFlag(cmd, "use-defaults"); shouldUseDefaults {
 			tmpl.UseDefaultValues()
 		}
+
+		tlog.SetLogLevel(GetStringFlag(cmd, "log-level"))
 
 		executeTemplate := func() error {
 			parentDir := filepath.Dir(targetDir)

--- a/pkg/prompt/prompt_test.go
+++ b/pkg/prompt/prompt_test.go
@@ -49,7 +49,7 @@ func TestNewBooleanPromptFunc(t *testing.T) {
 
 	expectedPromptMsg := "Please choose a value for \"fieldName\""
 	if msg != expectedPromptMsg {
-		t.Errorf("boolPrompt(%q).PromptMessage(%q) expected %q got %q", defval, name, expectedPromptMsg, msg)
+		t.Errorf("boolPrompt(%t).PromptMessage(%q) expected %q got %q", defval, name, expectedPromptMsg, msg)
 	}
 
 	choiceCases := []struct {
@@ -73,7 +73,7 @@ func TestNewBooleanPromptFunc(t *testing.T) {
 	for _, c := range choiceCases {
 		val, err := boolPrompt.EvaluateChoice(c.choice)
 		if err != nil {
-			t.Errorf("boolPrompt(%q).EvaluateChoice(%q) got error %q", defval, c.choice, err)
+			t.Errorf("boolPrompt(%t).EvaluateChoice(%q) got error %q", defval, c.choice, err)
 			continue
 		}
 

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -142,15 +142,17 @@ func (t *dirTemplate) BindPrompts() {
 		}
 
 		if t.ShouldUseDefaults {
-			t.FuncMap[s] = func() interface{} {
-				switch v := v.(type) {
-				// First is the default value if it's a slice
-				case []interface{}:
-					return v[0]
-				}
+			t.FuncMap[s] = func(val interface{}) func() interface{} {
+				return func() interface{} {
+					switch val := val.(type) {
+					// First is the default value if it's a slice
+					case []interface{}:
+						return val[0]
+					}
 
-				return v
-			}
+					return v
+				}
+			}(t.Context[s])
 		} else {
 			t.FuncMap[s] = prompt.New(s, v)
 		}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -150,9 +150,9 @@ func (t *dirTemplate) BindPrompts() {
 						return val[0]
 					}
 
-					return v
+					return val
 				}
-			}(t.Context[s])
+			}(v)
 		} else {
 			t.FuncMap[s] = prompt.New(s, v)
 		}


### PR DESCRIPTION
It was getting the last value of v instead of the specific value at the time.

So I noticed this happening when I performed the fallowing:
```
boilr template use <template> <targe> -f
```

So -f should use the defaults without prompting... what happend was dat it would fill in the last value inside the `project.json` and fill that in on all spots.