### PR TITLE
Ensuring that the entire folder path structure does exist. I've seen …

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -198,7 +198,7 @@ func (t *dirTemplate) Execute(dirPrefix string) error {
 		target := filepath.Join(dirPrefix, newName)
 
 		if info.IsDir() {
-			if err := os.Mkdir(target, 0755); err != nil {
+			if err := os.MkdirAll(target, 0755); err != nil {
 				if !os.IsExist(err) {
 					return err
 				}


### PR DESCRIPTION
…some intermittent issues on mac where the temporary folder had some missing folders within the path, hence the library is not able to create the folder. Using the MkdirAll solved the problem

Signed-off-by: Neville Bonavia <neville.bonavia@gig.com>